### PR TITLE
Fixed Linux static library build, deactivated debug messages

### DIFF
--- a/api/core/CMakeLists.txt
+++ b/api/core/CMakeLists.txt
@@ -4,6 +4,7 @@ project(libvatek_core)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(core_INC_BRIDGE
     inc/bridge/bridge_base.h
@@ -316,6 +317,7 @@ elseif(UNIX AND NOT APPLE)
 
 	set(ORIGINAL_STATIC_LIB_NAME vatek_core_static)
 	add_library(${ORIGINAL_STATIC_LIB_NAME} STATIC ${sdk2_SOURCES} ${sdk2_HEADERS})
+	set_target_properties(${ORIGINAL_STATIC_LIB_NAME} PROPERTIES OUTPUT_NAME vatek_core)
 
 	target_link_libraries(${ORIGINAL_STATIC_LIB_NAME} PRIVATE usb-1.0)
 	target_link_libraries(${ORIGINAL_STATIC_LIB_NAME} PRIVATE ${CMAKE_DL_LIBS})

--- a/api/core/src/cross/os/linux/linux_mutex.c
+++ b/api/core/src/cross/os/linux/linux_mutex.c
@@ -2,8 +2,6 @@
 #include <cross/cross_os_api.h>
 #include <pthread.h>
 
-#define MUTEX_EN_DBG                 1
-
 #if MUTEX_EN_DBG
     #define _mlockd                  _cos_log
 #else

--- a/api/core/src/cross/os/linux/linux_smem.c
+++ b/api/core/src/cross/os/linux/linux_smem.c
@@ -8,8 +8,6 @@
 
 #include <sys/mman.h>
 
-#define SMEM_EN_DBG                 1
-
 #if SMEM_EN_DBG
     #define _smemd                  _cos_log
 #else


### PR DESCRIPTION
- All code is made position-independent. This was not the case with
  the Linux static library. Nowadays, position-independent code shall
  be used everywhere. Without it, ASLR (a security feature to prevent
  ROP) cannot be activated.

- The Linux static library is installed as libvatek_core.a instead
  of libvatek_core_static.a.

- Deactivated debug trace by default in mutex and smem on Linux and
  macOS.