### PR TITLE
Fix incompatible pointer type

### DIFF
--- a/api/core/src/core/storage_section.c
+++ b/api/core/src/core/storage_section.c
@@ -440,7 +440,7 @@ vatek_result storage_r2tune_get(Pr2_tune_handle pr2,uint8_t* psection)
 void storage_chip_config_reset(Pstorage_chip_config pcfg)
 {
 	const char* filename = "modulation.mudul";
-	const char* str = &default_chip_config;
+	const storage_chip_config* str = &default_chip_config;
 	char buffer[sizeof(storage_chip_config)];
 
 	FILE* output_file = fopen(filename, "rb+");


### PR DESCRIPTION
Before gcc 14, the compilation reported a warning: incompatible pointer types initializing 'const char *' with an expression of type 'const storage_chip_config *'

Starting with gcc 14 (as seen on Fedora 40 on Arm64), this becomes an error and the build fails.